### PR TITLE
修复swift package编译脚本报网络错误问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ dependencies: [
 
 ## Build Scripts
 ```bash
-swift package BuildFFmpeg --disable-sandbox enable-libdav1d enable-openssl enable-libsrt
+swift package --disable-sandbox BuildFFmpeg enable-libdav1d enable-openssl enable-libsrt
 
 /// build MPV
-swift package BuildFFmpeg --disable-sandbox enable-libdav1d enable-openssl enable-libsrt enable-libfreetype enable-libfribidi enable-harfbuzz enable-libass enable-mpv platforms=macos
+swift package --disable-sandbox BuildFFmpeg enable-libdav1d enable-openssl enable-libsrt enable-libfreetype enable-libfribidi enable-harfbuzz enable-libass enable-mpv platforms=macos
 ```
 ## Executable product
 ```bash
@@ -42,7 +42,7 @@ swift package BuildFFmpeg h
 
 ```bash
 Usage: swift package BuildFFmpeg [OPTION]...
-Demo: swift package BuildFFmpeg --disable-sandbox enable-libdav1d enable-openssl enable-libsrt
+Demo: swift package --disable-sandbox BuildFFmpeg enable-libdav1d enable-openssl enable-libsrt
 Options:
     h                   display this help and exit
     enable-debug,       build ffmpeg with debug information


### PR DESCRIPTION
`--disable-sandbox`放在后面，会导致无法联网，放在前面则可以

```shell
swift package --disable-sandbox BuildFFmpeg enable-libdav1d enable-openssl enable-libsrt
```
问题见这里
https://github.com/kingslay/FFmpegKit/issues/5

xcode 14.3.1