### PR TITLE
修正 CFBundleIdentifier

### DIFF
--- a/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 <key>CFBundleExecutable</key>
 <string>libshaderc_combined</string>
 <key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc_combined</string>
+<string>com.kintan.ksplayer.libshaderc-combined</string>
 <key>CFBundleInfoDictionaryVersion</key>
 <string>6.0</string>
 <key>CFBundleName</key>


### PR DESCRIPTION
## 修正 CFBundleIdentifier

### 說明
為了提高應用的兼容性和符合 Apple 的命名慣例，將 `CFBundleIdentifier` 從 `com.kintan.ksplayer.libshaderc_combined` 修改為 `com.kintan.ksplayer.libshaderc-combined`。

### 變更內容
- 更新 `Info.plist` 文件中的 `CFBundleIdentifier`。
- 確保所有相關的配置和引用都已更新以匹配新標識符。

### 影響
此變更將解決在某些環境中出現的兼容性問題，並確保應用能夠正常運行。

### 測試
已在模擬器和真機上進行測試，確認應用能夠正常啟動和運行。

### 相關問題
無

如果不更新此 info 條目，將可能在遞交給 App Store 時候被拒絕提示

```
[20:19:33]: [ContentDelivery.Uploader.6000010E40C0] Asset validation failed (90049) This bundle is invalid. The bundle at path Payload/***.app/Frameworks/libshaderc_combined.framework has an invalid CFBundleIdentifier 'com.kintan.ksplayer.libshaderc_combined' There are invalid characters(characters that are not dots, hyphen and alphanumerics) that have been replaced with their code point 'com.kintan.ksplayer.libshaderc\u005fcombined' CFBundleIdentifier must be present, must contain only alphanumerics, dots, hyphens and must not end with a dot. [see the Core Foundation Keys at https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102070-TPXREF105] (ID: e2d1e428-93b0-4488-a4b4-f8c60450585a)
[20:19:33]: Error uploading '/var/folders/k1/jx5_bpgn4xb12xy9ml6k9kph0000gn/T/725a1486-69e5-44ff-b40c-4604baccd40f.ipa'.
[20:19:33]: Asset validation failed This bundle is invalid. The bundle at path Payload/*******/Frameworks/libshaderc_combined.framework has an invalid CFBundleIdentifier 'com.kintan.ksplayer.libshaderc_combined' There are invalid characters(characters that are not dots, hyphen and alphanumerics) that have been replaced with their code point 'com.kintan.ksplayer.libshaderc\u005fcombined' CFBundleIdentifier must be present, must contain only alphanumerics, dots, hyphens and must not end with a dot. [see the Core Foundation Keys at https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102070-TPXREF105] (ID: e2d1e428-93b0-4488-a4b4-f8c60450585a) (90049)
[20:19:33]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.

```