### PR TITLE
Fix/bundle identifier

### DIFF
--- a/Plugins/BuildFFmpeg/main.swift
+++ b/Plugins/BuildFFmpeg/main.swift
@@ -654,7 +654,7 @@ class BaseBuild {
     }
 
     private func createPlist(path: String, name: String, minVersion: String, platform: String) {
-        let identifier = "com.kintan.ksplayer." + name
+        let identifier = "com.iliasak91.ffmpegkit." + name
         let content = """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/Sources/Libavcodec.xcframework/Info.plist
+++ b/Sources/Libavcodec.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>maccatalyst</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavcodec.xcframework/Info.plist
+++ b/Sources/Libavcodec.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavcodec.xcframework/ios-arm64/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/ios-arm64/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/ios-arm64/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/ios-arm64/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/ios-arm64_x86_64-maccatalyst/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/ios-arm64_x86_64-maccatalyst/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/ios-arm64_x86_64-maccatalyst/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/ios-arm64_x86_64-maccatalyst/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/ios-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/ios-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/ios-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/ios-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/macos-arm64_x86_64/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/macos-arm64_x86_64/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/macos-arm64_x86_64/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/macos-arm64_x86_64/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/tvos-arm64_arm64e/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/tvos-arm64_arm64e/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/tvos-arm64_arm64e/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/tvos-arm64_arm64e/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/tvos-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/tvos-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/tvos-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/tvos-arm64_x86_64-simulator/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/xros-arm64-simulator/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/xros-arm64-simulator/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/xros-arm64-simulator/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/xros-arm64-simulator/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavcodec.xcframework/xros-arm64/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/xros-arm64/Libavcodec.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavcodec</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavcodec</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavcodec.xcframework/xros-arm64/Libavcodec.framework/Info.plist
+++ b/Sources/Libavcodec.xcframework/xros-arm64/Libavcodec.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavcodec</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavcodec</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavcodec</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavcodec</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavcodec</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/Info.plist
+++ b/Sources/Libavdevice.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavdevice.xcframework/Info.plist
+++ b/Sources/Libavdevice.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavdevice.xcframework/ios-arm64/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/ios-arm64/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/ios-arm64/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/ios-arm64/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/ios-arm64_x86_64-maccatalyst/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/ios-arm64_x86_64-maccatalyst/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/ios-arm64_x86_64-maccatalyst/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/ios-arm64_x86_64-maccatalyst/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/ios-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/ios-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/ios-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/ios-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/macos-arm64_x86_64/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/macos-arm64_x86_64/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/macos-arm64_x86_64/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/macos-arm64_x86_64/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/tvos-arm64_arm64e/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/tvos-arm64_arm64e/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/tvos-arm64_arm64e/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/tvos-arm64_arm64e/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/tvos-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/tvos-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/tvos-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/tvos-arm64_x86_64-simulator/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/xros-arm64-simulator/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/xros-arm64-simulator/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavdevice.xcframework/xros-arm64-simulator/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/xros-arm64-simulator/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/xros-arm64/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/xros-arm64/Libavdevice.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavdevice</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavdevice</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavdevice.xcframework/xros-arm64/Libavdevice.framework/Info.plist
+++ b/Sources/Libavdevice.xcframework/xros-arm64/Libavdevice.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavdevice</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavdevice</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavdevice</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavdevice</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavdevice</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/Info.plist
+++ b/Sources/Libavfilter.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>tvos</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavfilter.xcframework/Info.plist
+++ b/Sources/Libavfilter.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavfilter.xcframework/ios-arm64/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/ios-arm64/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/ios-arm64/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/ios-arm64/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/ios-arm64_x86_64-maccatalyst/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/ios-arm64_x86_64-maccatalyst/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/ios-arm64_x86_64-maccatalyst/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/ios-arm64_x86_64-maccatalyst/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/ios-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/ios-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/ios-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/ios-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/macos-arm64_x86_64/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/macos-arm64_x86_64/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/macos-arm64_x86_64/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/macos-arm64_x86_64/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/tvos-arm64_arm64e/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/tvos-arm64_arm64e/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/tvos-arm64_arm64e/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/tvos-arm64_arm64e/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/tvos-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/tvos-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/tvos-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/tvos-arm64_x86_64-simulator/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/xros-arm64-simulator/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/xros-arm64-simulator/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/xros-arm64-simulator/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/xros-arm64-simulator/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavfilter.xcframework/xros-arm64/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/xros-arm64/Libavfilter.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavfilter</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavfilter</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavfilter</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavfilter</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavfilter</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavfilter.xcframework/xros-arm64/Libavfilter.framework/Info.plist
+++ b/Sources/Libavfilter.xcframework/xros-arm64/Libavfilter.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavfilter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavfilter</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/Info.plist
+++ b/Sources/Libavformat.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavformat.xcframework/Info.plist
+++ b/Sources/Libavformat.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavformat.xcframework/ios-arm64/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/ios-arm64/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/ios-arm64/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/ios-arm64/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/ios-arm64_x86_64-maccatalyst/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/ios-arm64_x86_64-maccatalyst/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/ios-arm64_x86_64-maccatalyst/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/ios-arm64_x86_64-maccatalyst/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/ios-arm64_x86_64-simulator/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/ios-arm64_x86_64-simulator/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/ios-arm64_x86_64-simulator/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/ios-arm64_x86_64-simulator/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/macos-arm64_x86_64/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/macos-arm64_x86_64/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/macos-arm64_x86_64/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/macos-arm64_x86_64/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/tvos-arm64_arm64e/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/tvos-arm64_arm64e/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/tvos-arm64_arm64e/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/tvos-arm64_arm64e/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/tvos-arm64_x86_64-simulator/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/tvos-arm64_x86_64-simulator/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/tvos-arm64_x86_64-simulator/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/tvos-arm64_x86_64-simulator/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/xros-arm64-simulator/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/xros-arm64-simulator/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/xros-arm64-simulator/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/xros-arm64-simulator/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavformat.xcframework/xros-arm64/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/xros-arm64/Libavformat.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavformat</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavformat</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavformat.xcframework/xros-arm64/Libavformat.framework/Info.plist
+++ b/Sources/Libavformat.xcframework/xros-arm64/Libavformat.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavformat</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavformat</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavformat</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavformat</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavformat</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/Info.plist
+++ b/Sources/Libavutil.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavutil.xcframework/Info.plist
+++ b/Sources/Libavutil.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>xros</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libavutil.xcframework/ios-arm64/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/ios-arm64/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/ios-arm64/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/ios-arm64/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/ios-arm64_x86_64-maccatalyst/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/ios-arm64_x86_64-maccatalyst/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/ios-arm64_x86_64-maccatalyst/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/ios-arm64_x86_64-maccatalyst/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/ios-arm64_x86_64-simulator/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/ios-arm64_x86_64-simulator/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/ios-arm64_x86_64-simulator/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/ios-arm64_x86_64-simulator/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/macos-arm64_x86_64/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/macos-arm64_x86_64/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/macos-arm64_x86_64/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/macos-arm64_x86_64/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/tvos-arm64_arm64e/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/tvos-arm64_arm64e/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/tvos-arm64_arm64e/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/tvos-arm64_arm64e/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/tvos-arm64_x86_64-simulator/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/tvos-arm64_x86_64-simulator/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/tvos-arm64_x86_64-simulator/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/tvos-arm64_x86_64-simulator/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/xros-arm64-simulator/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/xros-arm64-simulator/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/xros-arm64-simulator/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/xros-arm64-simulator/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libavutil.xcframework/xros-arm64/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/xros-arm64/Libavutil.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libavutil</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libavutil</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libavutil</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libavutil</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libavutil</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libavutil.xcframework/xros-arm64/Libavutil.framework/Info.plist
+++ b/Sources/Libavutil.xcframework/xros-arm64/Libavutil.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libavutil</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libavutil</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/Info.plist
+++ b/Sources/Libswresample.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libswresample.xcframework/Info.plist
+++ b/Sources/Libswresample.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libswresample.xcframework/ios-arm64/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/ios-arm64/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/ios-arm64/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/ios-arm64/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/ios-arm64_x86_64-maccatalyst/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/ios-arm64_x86_64-maccatalyst/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/ios-arm64_x86_64-maccatalyst/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/ios-arm64_x86_64-maccatalyst/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/ios-arm64_x86_64-simulator/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/ios-arm64_x86_64-simulator/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/ios-arm64_x86_64-simulator/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/ios-arm64_x86_64-simulator/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/macos-arm64_x86_64/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/macos-arm64_x86_64/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/macos-arm64_x86_64/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/macos-arm64_x86_64/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/tvos-arm64_arm64e/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/tvos-arm64_arm64e/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/tvos-arm64_arm64e/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/tvos-arm64_arm64e/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/tvos-arm64_x86_64-simulator/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/tvos-arm64_x86_64-simulator/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/tvos-arm64_x86_64-simulator/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/tvos-arm64_x86_64-simulator/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/xros-arm64-simulator/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/xros-arm64-simulator/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswresample.xcframework/xros-arm64-simulator/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/xros-arm64-simulator/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/xros-arm64/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/xros-arm64/Libswresample.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswresample</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswresample</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswresample.xcframework/xros-arm64/Libswresample.framework/Info.plist
+++ b/Sources/Libswresample.xcframework/xros-arm64/Libswresample.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswresample</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswresample</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswresample</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswresample</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswresample</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/Info.plist
+++ b/Sources/Libswscale.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libswscale.xcframework/Info.plist
+++ b/Sources/Libswscale.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/Libswscale.xcframework/ios-arm64/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/ios-arm64/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/ios-arm64/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/ios-arm64/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/ios-arm64_x86_64-maccatalyst/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/ios-arm64_x86_64-maccatalyst/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/ios-arm64_x86_64-maccatalyst/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/ios-arm64_x86_64-maccatalyst/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/ios-arm64_x86_64-simulator/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/ios-arm64_x86_64-simulator/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/ios-arm64_x86_64-simulator/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/ios-arm64_x86_64-simulator/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/macos-arm64_x86_64/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/macos-arm64_x86_64/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/macos-arm64_x86_64/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/macos-arm64_x86_64/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/tvos-arm64_arm64e/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/tvos-arm64_arm64e/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/tvos-arm64_arm64e/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/tvos-arm64_arm64e/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/tvos-arm64_x86_64-simulator/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/tvos-arm64_x86_64-simulator/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/tvos-arm64_x86_64-simulator/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/tvos-arm64_x86_64-simulator/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/xros-arm64-simulator/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/xros-arm64-simulator/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/Libswscale.xcframework/xros-arm64-simulator/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/xros-arm64-simulator/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/xros-arm64/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/xros-arm64/Libswscale.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Libswscale</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libswscale</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/Libswscale.xcframework/xros-arm64/Libswscale.framework/Info.plist
+++ b/Sources/Libswscale.xcframework/xros-arm64/Libswscale.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>Libswscale</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.Libswscale</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>Libswscale</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>Libswscale</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Libswscale</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/MoltenVK.xcframework/Info.plist
+++ b/Sources/MoltenVK.xcframework/Info.plist
@@ -132,7 +132,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.moltenvk</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/MoltenVK.xcframework/Info.plist
+++ b/Sources/MoltenVK.xcframework/Info.plist
@@ -131,6 +131,8 @@
 			<string>xros</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/gmp.xcframework/Info.plist
+++ b/Sources/gmp.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/gmp.xcframework/Info.plist
+++ b/Sources/gmp.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/gmp.xcframework/ios-arm64/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/ios-arm64/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/ios-arm64/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/ios-arm64/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/ios-arm64_x86_64-maccatalyst/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/ios-arm64_x86_64-maccatalyst/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/ios-arm64_x86_64-maccatalyst/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/ios-arm64_x86_64-maccatalyst/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/ios-arm64_x86_64-simulator/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/ios-arm64_x86_64-simulator/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/ios-arm64_x86_64-simulator/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/ios-arm64_x86_64-simulator/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/macos-arm64_x86_64/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/macos-arm64_x86_64/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/macos-arm64_x86_64/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/macos-arm64_x86_64/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/tvos-arm64_arm64e/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/tvos-arm64_arm64e/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/tvos-arm64_arm64e/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/tvos-arm64_arm64e/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/tvos-arm64_x86_64-simulator/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/tvos-arm64_x86_64-simulator/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/tvos-arm64_x86_64-simulator/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/tvos-arm64_x86_64-simulator/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/xros-arm64-simulator/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/xros-arm64-simulator/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/xros-arm64-simulator/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/xros-arm64-simulator/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gmp.xcframework/xros-arm64/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/xros-arm64/gmp.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gmp</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gmp</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gmp.xcframework/xros-arm64/gmp.framework/Info.plist
+++ b/Sources/gmp.xcframework/xros-arm64/gmp.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gmp</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gmp</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gmp</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gmp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gmp</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/Info.plist
+++ b/Sources/gnutls.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/gnutls.xcframework/Info.plist
+++ b/Sources/gnutls.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/gnutls.xcframework/ios-arm64/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/ios-arm64/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/ios-arm64/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/ios-arm64/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/ios-arm64_x86_64-maccatalyst/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/ios-arm64_x86_64-maccatalyst/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/ios-arm64_x86_64-maccatalyst/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/ios-arm64_x86_64-maccatalyst/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/ios-arm64_x86_64-simulator/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/ios-arm64_x86_64-simulator/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/ios-arm64_x86_64-simulator/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/ios-arm64_x86_64-simulator/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/macos-arm64_x86_64/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/macos-arm64_x86_64/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/macos-arm64_x86_64/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/macos-arm64_x86_64/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/tvos-arm64_arm64e/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/tvos-arm64_arm64e/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/tvos-arm64_arm64e/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/tvos-arm64_arm64e/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/tvos-arm64_x86_64-simulator/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/tvos-arm64_x86_64-simulator/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/tvos-arm64_x86_64-simulator/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/tvos-arm64_x86_64-simulator/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/xros-arm64-simulator/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/xros-arm64-simulator/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/xros-arm64-simulator/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/xros-arm64-simulator/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/gnutls.xcframework/xros-arm64/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/xros-arm64/gnutls.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>gnutls</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.gnutls</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/gnutls.xcframework/xros-arm64/gnutls.framework/Info.plist
+++ b/Sources/gnutls.xcframework/xros-arm64/gnutls.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>gnutls</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.gnutls</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>gnutls</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>gnutls</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>gnutls</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/Info.plist
+++ b/Sources/hogweed.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>ios</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/hogweed.xcframework/Info.plist
+++ b/Sources/hogweed.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/hogweed.xcframework/ios-arm64/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/ios-arm64/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/ios-arm64/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/ios-arm64/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/ios-arm64_x86_64-maccatalyst/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/ios-arm64_x86_64-maccatalyst/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/ios-arm64_x86_64-maccatalyst/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/ios-arm64_x86_64-maccatalyst/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/ios-arm64_x86_64-simulator/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/ios-arm64_x86_64-simulator/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/ios-arm64_x86_64-simulator/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/ios-arm64_x86_64-simulator/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/macos-arm64_x86_64/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/macos-arm64_x86_64/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/macos-arm64_x86_64/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/macos-arm64_x86_64/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/tvos-arm64_arm64e/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/tvos-arm64_arm64e/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/tvos-arm64_arm64e/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/tvos-arm64_arm64e/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/tvos-arm64_x86_64-simulator/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/tvos-arm64_x86_64-simulator/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/tvos-arm64_x86_64-simulator/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/tvos-arm64_x86_64-simulator/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/xros-arm64-simulator/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/xros-arm64-simulator/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/xros-arm64-simulator/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/xros-arm64-simulator/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/hogweed.xcframework/xros-arm64/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/xros-arm64/hogweed.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>hogweed</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.hogweed</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/hogweed.xcframework/xros-arm64/hogweed.framework/Info.plist
+++ b/Sources/hogweed.xcframework/xros-arm64/hogweed.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>hogweed</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.hogweed</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>hogweed</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>hogweed</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>hogweed</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/Info.plist
+++ b/Sources/lcms2.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>xros</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/lcms2.xcframework/Info.plist
+++ b/Sources/lcms2.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/lcms2.xcframework/ios-arm64/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/ios-arm64/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/ios-arm64/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/ios-arm64/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/ios-arm64_x86_64-maccatalyst/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/ios-arm64_x86_64-maccatalyst/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/ios-arm64_x86_64-maccatalyst/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/ios-arm64_x86_64-maccatalyst/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/ios-arm64_x86_64-simulator/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/ios-arm64_x86_64-simulator/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/ios-arm64_x86_64-simulator/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/ios-arm64_x86_64-simulator/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/macos-arm64_x86_64/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/macos-arm64_x86_64/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/macos-arm64_x86_64/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/macos-arm64_x86_64/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/tvos-arm64_arm64e/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/tvos-arm64_arm64e/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/tvos-arm64_arm64e/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/tvos-arm64_arm64e/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/tvos-arm64_x86_64-simulator/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/tvos-arm64_x86_64-simulator/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/tvos-arm64_x86_64-simulator/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/tvos-arm64_x86_64-simulator/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/xros-arm64-simulator/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/xros-arm64-simulator/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/xros-arm64-simulator/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/xros-arm64-simulator/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/lcms2.xcframework/xros-arm64/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/xros-arm64/lcms2.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>lcms2</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.lcms2</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/lcms2.xcframework/xros-arm64/lcms2.framework/Info.plist
+++ b/Sources/lcms2.xcframework/xros-arm64/lcms2.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>lcms2</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.lcms2</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>lcms2</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>lcms2</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>lcms2</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/Info.plist
+++ b/Sources/libass.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libass.xcframework/Info.plist
+++ b/Sources/libass.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libass.xcframework/ios-arm64/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/ios-arm64/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/ios-arm64/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/ios-arm64/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/ios-arm64_x86_64-maccatalyst/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/ios-arm64_x86_64-maccatalyst/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/ios-arm64_x86_64-maccatalyst/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/ios-arm64_x86_64-maccatalyst/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/ios-arm64_x86_64-simulator/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/ios-arm64_x86_64-simulator/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/ios-arm64_x86_64-simulator/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/ios-arm64_x86_64-simulator/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/macos-arm64_x86_64/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/macos-arm64_x86_64/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/macos-arm64_x86_64/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/macos-arm64_x86_64/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/tvos-arm64_arm64e/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/tvos-arm64_arm64e/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/tvos-arm64_arm64e/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/tvos-arm64_arm64e/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/tvos-arm64_x86_64-simulator/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/tvos-arm64_x86_64-simulator/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/tvos-arm64_x86_64-simulator/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/tvos-arm64_x86_64-simulator/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/xros-arm64-simulator/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/xros-arm64-simulator/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/xros-arm64-simulator/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/xros-arm64-simulator/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libass.xcframework/xros-arm64/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/xros-arm64/libass.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libass</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libass</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libass.xcframework/xros-arm64/libass.framework/Info.plist
+++ b/Sources/libass.xcframework/xros-arm64/libass.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libass</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libass</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libass</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libass</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libass</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libbluray.xcframework/Info.plist
+++ b/Sources/libbluray.xcframework/Info.plist
@@ -21,7 +21,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libbluray</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libbluray.xcframework/Info.plist
+++ b/Sources/libbluray.xcframework/Info.plist
@@ -20,6 +20,8 @@
 			<string>macos</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libbluray.xcframework/macos-arm64_x86_64/libbluray.framework/Info.plist
+++ b/Sources/libbluray.xcframework/macos-arm64_x86_64/libbluray.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libbluray</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libbluray</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libbluray.xcframework/macos-arm64_x86_64/libbluray.framework/Info.plist
+++ b/Sources/libbluray.xcframework/macos-arm64_x86_64/libbluray.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libbluray</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libbluray</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libbluray</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libbluray</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libbluray</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/Info.plist
+++ b/Sources/libdav1d.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libdav1d.xcframework/Info.plist
+++ b/Sources/libdav1d.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libdav1d.xcframework/ios-arm64/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/ios-arm64/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/ios-arm64/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/ios-arm64/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/ios-arm64_x86_64-maccatalyst/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/ios-arm64_x86_64-maccatalyst/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/ios-arm64_x86_64-maccatalyst/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/ios-arm64_x86_64-maccatalyst/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/ios-arm64_x86_64-simulator/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/ios-arm64_x86_64-simulator/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/ios-arm64_x86_64-simulator/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/ios-arm64_x86_64-simulator/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/macos-arm64_x86_64/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/macos-arm64_x86_64/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/macos-arm64_x86_64/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/macos-arm64_x86_64/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/tvos-arm64_arm64e/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/tvos-arm64_arm64e/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/tvos-arm64_arm64e/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/tvos-arm64_arm64e/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/tvos-arm64_x86_64-simulator/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/tvos-arm64_x86_64-simulator/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/tvos-arm64_x86_64-simulator/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/tvos-arm64_x86_64-simulator/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/xros-arm64-simulator/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/xros-arm64-simulator/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/xros-arm64-simulator/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/xros-arm64-simulator/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libdav1d.xcframework/xros-arm64/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/xros-arm64/libdav1d.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libdav1d</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libdav1d</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libdav1d</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libdav1d</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libdav1d</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libdav1d.xcframework/xros-arm64/libdav1d.framework/Info.plist
+++ b/Sources/libdav1d.xcframework/xros-arm64/libdav1d.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libdav1d</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libdav1d</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/Info.plist
+++ b/Sources/libfontconfig.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>xros</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libfontconfig.xcframework/Info.plist
+++ b/Sources/libfontconfig.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libfontconfig.xcframework/ios-arm64/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/ios-arm64/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/ios-arm64/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/ios-arm64/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/ios-arm64_x86_64-maccatalyst/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/ios-arm64_x86_64-maccatalyst/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/ios-arm64_x86_64-maccatalyst/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/ios-arm64_x86_64-maccatalyst/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/ios-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/ios-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/ios-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/ios-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/macos-arm64_x86_64/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/macos-arm64_x86_64/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/macos-arm64_x86_64/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/macos-arm64_x86_64/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/tvos-arm64_arm64e/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/tvos-arm64_arm64e/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/tvos-arm64_arm64e/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/tvos-arm64_arm64e/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/tvos-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/tvos-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/tvos-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/tvos-arm64_x86_64-simulator/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/xros-arm64-simulator/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/xros-arm64-simulator/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/xros-arm64-simulator/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/xros-arm64-simulator/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfontconfig.xcframework/xros-arm64/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/xros-arm64/libfontconfig.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfontconfig</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfontconfig</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfontconfig</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfontconfig</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfontconfig</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfontconfig.xcframework/xros-arm64/libfontconfig.framework/Info.plist
+++ b/Sources/libfontconfig.xcframework/xros-arm64/libfontconfig.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfontconfig</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfontconfig</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/Info.plist
+++ b/Sources/libfreetype.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libfreetype.xcframework/Info.plist
+++ b/Sources/libfreetype.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libfreetype.xcframework/ios-arm64/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/ios-arm64/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/ios-arm64/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/ios-arm64/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/ios-arm64_x86_64-maccatalyst/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/ios-arm64_x86_64-maccatalyst/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/ios-arm64_x86_64-maccatalyst/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/ios-arm64_x86_64-maccatalyst/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/ios-arm64_x86_64-simulator/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/ios-arm64_x86_64-simulator/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/ios-arm64_x86_64-simulator/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/ios-arm64_x86_64-simulator/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/macos-arm64_x86_64/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/macos-arm64_x86_64/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/macos-arm64_x86_64/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/macos-arm64_x86_64/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/tvos-arm64_arm64e/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/tvos-arm64_arm64e/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/tvos-arm64_arm64e/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/tvos-arm64_arm64e/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/tvos-arm64_x86_64-simulator/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/tvos-arm64_x86_64-simulator/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/tvos-arm64_x86_64-simulator/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/tvos-arm64_x86_64-simulator/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/xros-arm64-simulator/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/xros-arm64-simulator/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/xros-arm64-simulator/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/xros-arm64-simulator/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfreetype.xcframework/xros-arm64/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/xros-arm64/libfreetype.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfreetype</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfreetype</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfreetype.xcframework/xros-arm64/libfreetype.framework/Info.plist
+++ b/Sources/libfreetype.xcframework/xros-arm64/libfreetype.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfreetype</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfreetype</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfreetype</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfreetype</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfreetype</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/Info.plist
+++ b/Sources/libfribidi.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libfribidi.xcframework/Info.plist
+++ b/Sources/libfribidi.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libfribidi.xcframework/ios-arm64/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/ios-arm64/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/ios-arm64/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/ios-arm64/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/ios-arm64_x86_64-maccatalyst/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/ios-arm64_x86_64-maccatalyst/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/ios-arm64_x86_64-maccatalyst/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/ios-arm64_x86_64-maccatalyst/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/ios-arm64_x86_64-simulator/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/ios-arm64_x86_64-simulator/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/ios-arm64_x86_64-simulator/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/ios-arm64_x86_64-simulator/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/macos-arm64_x86_64/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/macos-arm64_x86_64/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/macos-arm64_x86_64/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/macos-arm64_x86_64/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/tvos-arm64_arm64e/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/tvos-arm64_arm64e/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/tvos-arm64_arm64e/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/tvos-arm64_arm64e/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/tvos-arm64_x86_64-simulator/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/tvos-arm64_x86_64-simulator/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/tvos-arm64_x86_64-simulator/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/tvos-arm64_x86_64-simulator/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/xros-arm64-simulator/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/xros-arm64-simulator/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/xros-arm64-simulator/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/xros-arm64-simulator/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libfribidi.xcframework/xros-arm64/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/xros-arm64/libfribidi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libfribidi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libfribidi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libfribidi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libfribidi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libfribidi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libfribidi.xcframework/xros-arm64/libfribidi.framework/Info.plist
+++ b/Sources/libfribidi.xcframework/xros-arm64/libfribidi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libfribidi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libfribidi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>xros</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libharfbuzz.xcframework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libharfbuzz.xcframework/ios-arm64/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/ios-arm64/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/ios-arm64/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/ios-arm64/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-maccatalyst/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-maccatalyst/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-maccatalyst/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-maccatalyst/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/ios-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/macos-arm64_x86_64/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/macos-arm64_x86_64/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/macos-arm64_x86_64/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/macos-arm64_x86_64/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/tvos-arm64_arm64e/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/tvos-arm64_arm64e/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/tvos-arm64_arm64e/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/tvos-arm64_arm64e/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/tvos-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/tvos-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/tvos-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/tvos-arm64_x86_64-simulator/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/xros-arm64-simulator/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/xros-arm64-simulator/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/xros-arm64-simulator/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/xros-arm64-simulator/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libharfbuzz.xcframework/xros-arm64/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/xros-arm64/libharfbuzz.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libharfbuzz</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libharfbuzz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libharfbuzz.xcframework/xros-arm64/libharfbuzz.framework/Info.plist
+++ b/Sources/libharfbuzz.xcframework/xros-arm64/libharfbuzz.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libharfbuzz</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libharfbuzz</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libharfbuzz</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libharfbuzz</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libharfbuzz</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/Info.plist
+++ b/Sources/libmpv.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>ios</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libmpv.xcframework/Info.plist
+++ b/Sources/libmpv.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libmpv.xcframework/ios-arm64/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/ios-arm64/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/ios-arm64/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/ios-arm64/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/ios-arm64_x86_64-maccatalyst/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/ios-arm64_x86_64-maccatalyst/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/ios-arm64_x86_64-maccatalyst/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/ios-arm64_x86_64-maccatalyst/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/ios-arm64_x86_64-simulator/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/ios-arm64_x86_64-simulator/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/ios-arm64_x86_64-simulator/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/ios-arm64_x86_64-simulator/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/macos-arm64_x86_64/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/macos-arm64_x86_64/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/macos-arm64_x86_64/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/macos-arm64_x86_64/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/tvos-arm64_arm64e/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/tvos-arm64_arm64e/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/tvos-arm64_arm64e/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/tvos-arm64_arm64e/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/tvos-arm64_x86_64-simulator/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/tvos-arm64_x86_64-simulator/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/tvos-arm64_x86_64-simulator/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/tvos-arm64_x86_64-simulator/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/xros-arm64-simulator/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/xros-arm64-simulator/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/xros-arm64-simulator/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/xros-arm64-simulator/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libmpv.xcframework/xros-arm64/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/xros-arm64/libmpv.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libmpv</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libmpv</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libmpv</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libmpv</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libmpv</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libmpv.xcframework/xros-arm64/libmpv.framework/Info.plist
+++ b/Sources/libmpv.xcframework/xros-arm64/libmpv.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libmpv</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libmpv</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/Info.plist
+++ b/Sources/libplacebo.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libplacebo.xcframework/Info.plist
+++ b/Sources/libplacebo.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libplacebo.xcframework/ios-arm64/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/ios-arm64/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/ios-arm64/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/ios-arm64/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/ios-arm64_x86_64-maccatalyst/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/ios-arm64_x86_64-maccatalyst/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/ios-arm64_x86_64-maccatalyst/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/ios-arm64_x86_64-maccatalyst/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/ios-arm64_x86_64-simulator/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/ios-arm64_x86_64-simulator/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/ios-arm64_x86_64-simulator/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/ios-arm64_x86_64-simulator/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/macos-arm64_x86_64/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/macos-arm64_x86_64/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/macos-arm64_x86_64/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/macos-arm64_x86_64/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/tvos-arm64_arm64e/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/tvos-arm64_arm64e/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/tvos-arm64_arm64e/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/tvos-arm64_arm64e/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/tvos-arm64_x86_64-simulator/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/tvos-arm64_x86_64-simulator/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/tvos-arm64_x86_64-simulator/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/tvos-arm64_x86_64-simulator/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/xros-arm64-simulator/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/xros-arm64-simulator/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libplacebo.xcframework/xros-arm64-simulator/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/xros-arm64-simulator/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/xros-arm64/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/xros-arm64/libplacebo.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libplacebo</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libplacebo</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libplacebo</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libplacebo</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libplacebo</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libplacebo.xcframework/xros-arm64/libplacebo.framework/Info.plist
+++ b/Sources/libplacebo.xcframework/xros-arm64/libplacebo.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libplacebo</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libplacebo</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libshaderc_combined.xcframework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libshaderc_combined.xcframework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/Info.plist b/Sources/libshaderc_combined.xcframework/Info.plist	(rejected hunks)
+@@ -131,7 +131,7 @@
+ 		</dict>
+ 	</array>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundlePackageType</key>
+ 	<string>XFWK</string>
+ 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/ios-arm64/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-maccatalyst/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/ios-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/macos-arm64_x86_64/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/tvos-arm64_arm64e/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/tvos-arm64_x86_64-simulator/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/xros-arm64-simulator/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libshaderc_combined</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libshaderc-combined</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libshaderc_combined</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libshaderc_combined</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libshaderc_combined</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libshaderc_combined</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist.rej
+++ b/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist.rej
@@ -1,0 +1,10 @@
+diff a/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist b/Sources/libshaderc_combined.xcframework/xros-arm64/libshaderc_combined.framework/Info.plist	(rejected hunks)
+@@ -7,7 +7,7 @@
+ 	<key>CFBundleExecutable</key>
+ 	<string>libshaderc_combined</string>
+ 	<key>CFBundleIdentifier</key>
+-	<string>com.iliasak91.ffmpegkit.libshaderc</string>
++	<string>com.iliasak91.ffmpegkit.libshaderc-combined</string>
+ 	<key>CFBundleInfoDictionaryVersion</key>
+ 	<string>6.0</string>
+ 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/Info.plist
+++ b/Sources/libsmbclient.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libsmbclient.xcframework/Info.plist
+++ b/Sources/libsmbclient.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libsmbclient.xcframework/ios-arm64/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/ios-arm64/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/ios-arm64/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/ios-arm64/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/ios-arm64_x86_64-maccatalyst/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/ios-arm64_x86_64-maccatalyst/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/ios-arm64_x86_64-maccatalyst/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/ios-arm64_x86_64-maccatalyst/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/ios-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/ios-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/ios-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/ios-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/macos-arm64_x86_64/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/macos-arm64_x86_64/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/macos-arm64_x86_64/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/macos-arm64_x86_64/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/tvos-arm64_arm64e/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/tvos-arm64_arm64e/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/tvos-arm64_arm64e/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/tvos-arm64_arm64e/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/tvos-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/tvos-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/tvos-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/tvos-arm64_x86_64-simulator/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/xros-arm64-simulator/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/xros-arm64-simulator/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/xros-arm64-simulator/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/xros-arm64-simulator/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsmbclient.xcframework/xros-arm64/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/xros-arm64/libsmbclient.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsmbclient</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsmbclient</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsmbclient</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsmbclient</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsmbclient</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsmbclient.xcframework/xros-arm64/libsmbclient.framework/Info.plist
+++ b/Sources/libsmbclient.xcframework/xros-arm64/libsmbclient.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsmbclient</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsmbclient</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/Info.plist
+++ b/Sources/libsrt.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>macos</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libsrt.xcframework/Info.plist
+++ b/Sources/libsrt.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libsrt.xcframework/ios-arm64/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/ios-arm64/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/ios-arm64/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/ios-arm64/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/ios-arm64_x86_64-maccatalyst/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/ios-arm64_x86_64-maccatalyst/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/ios-arm64_x86_64-maccatalyst/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/ios-arm64_x86_64-maccatalyst/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/ios-arm64_x86_64-simulator/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/ios-arm64_x86_64-simulator/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/ios-arm64_x86_64-simulator/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/ios-arm64_x86_64-simulator/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/macos-arm64_x86_64/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/macos-arm64_x86_64/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/macos-arm64_x86_64/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/macos-arm64_x86_64/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/tvos-arm64_arm64e/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/tvos-arm64_arm64e/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/tvos-arm64_arm64e/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/tvos-arm64_arm64e/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/tvos-arm64_x86_64-simulator/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/tvos-arm64_x86_64-simulator/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/tvos-arm64_x86_64-simulator/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/tvos-arm64_x86_64-simulator/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/xros-arm64-simulator/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/xros-arm64-simulator/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/xros-arm64-simulator/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/xros-arm64-simulator/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libsrt.xcframework/xros-arm64/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/xros-arm64/libsrt.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libsrt</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libsrt</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libsrt.xcframework/xros-arm64/libsrt.framework/Info.plist
+++ b/Sources/libsrt.xcframework/xros-arm64/libsrt.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libsrt</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libsrt</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libsrt</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libsrt</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libsrt</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/Info.plist
+++ b/Sources/libzvbi.xcframework/Info.plist
@@ -113,6 +113,8 @@
 			<string>xros</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libzvbi.xcframework/Info.plist
+++ b/Sources/libzvbi.xcframework/Info.plist
@@ -114,7 +114,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/libzvbi.xcframework/ios-arm64/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/ios-arm64/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libzvbi.xcframework/ios-arm64/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/ios-arm64/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/ios-arm64_x86_64-simulator/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/ios-arm64_x86_64-simulator/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libzvbi.xcframework/ios-arm64_x86_64-simulator/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/ios-arm64_x86_64-simulator/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/macos-arm64_x86_64/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/macos-arm64_x86_64/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libzvbi.xcframework/macos-arm64_x86_64/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/macos-arm64_x86_64/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/tvos-arm64_arm64e/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/tvos-arm64_arm64e/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libzvbi.xcframework/tvos-arm64_arm64e/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/tvos-arm64_arm64e/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/tvos-arm64_x86_64-simulator/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/tvos-arm64_x86_64-simulator/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libzvbi.xcframework/tvos-arm64_x86_64-simulator/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/tvos-arm64_x86_64-simulator/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/xros-arm64-simulator/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/xros-arm64-simulator/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/libzvbi.xcframework/xros-arm64-simulator/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/xros-arm64-simulator/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/xros-arm64/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/xros-arm64/libzvbi.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>libzvbi</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.libzvbi</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>libzvbi</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>libzvbi</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libzvbi</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/libzvbi.xcframework/xros-arm64/libzvbi.framework/Info.plist
+++ b/Sources/libzvbi.xcframework/xros-arm64/libzvbi.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>libzvbi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.libzvbi</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/Info.plist
+++ b/Sources/nettle.xcframework/Info.plist
@@ -130,6 +130,8 @@
 			<string>simulator</string>
 		</dict>
 	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/nettle.xcframework/Info.plist
+++ b/Sources/nettle.xcframework/Info.plist
@@ -131,7 +131,7 @@
 		</dict>
 	</array>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundlePackageType</key>
 	<string>XFWK</string>
 	<key>XCFrameworkFormatVersion</key>

--- a/Sources/nettle.xcframework/ios-arm64/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/ios-arm64/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/ios-arm64/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/ios-arm64/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/ios-arm64_x86_64-maccatalyst/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/ios-arm64_x86_64-maccatalyst/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/ios-arm64_x86_64-maccatalyst/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/ios-arm64_x86_64-maccatalyst/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>14.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>14.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/ios-arm64_x86_64-simulator/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/ios-arm64_x86_64-simulator/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/ios-arm64_x86_64-simulator/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/ios-arm64_x86_64-simulator/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>iPhoneSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/macos-arm64_x86_64/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/macos-arm64_x86_64/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/macos-arm64_x86_64/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/macos-arm64_x86_64/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>10.15</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>MacOSX</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>10.15</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/tvos-arm64_arm64e/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/tvos-arm64_arm64e/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVOS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVOS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/tvos-arm64_arm64e/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/tvos-arm64_arm64e/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/tvos-arm64_x86_64-simulator/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/tvos-arm64_x86_64-simulator/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/tvos-arm64_x86_64-simulator/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/tvos-arm64_x86_64-simulator/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>13.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>AppleTVSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>AppleTVSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>13.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/xros-arm64-simulator/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/xros-arm64-simulator/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Sources/nettle.xcframework/xros-arm64-simulator/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/xros-arm64-simulator/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XRSimulator</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XRSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/xros-arm64/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/xros-arm64/nettle.framework/Info.plist
@@ -2,31 +2,31 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-<key>CFBundleDevelopmentRegion</key>
-<string>en</string>
-<key>CFBundleExecutable</key>
-<string>nettle</string>
-<key>CFBundleIdentifier</key>
-<string>com.kintan.ksplayer.nettle</string>
-<key>CFBundleInfoDictionaryVersion</key>
-<string>6.0</string>
-<key>CFBundleName</key>
-<string>nettle</string>
-<key>CFBundlePackageType</key>
-<string>FMWK</string>
-<key>CFBundleShortVersionString</key>
-<string>87.88.520</string>
-<key>CFBundleVersion</key>
-<string>87.88.520</string>
-<key>CFBundleSignature</key>
-<string>????</string>
-<key>MinimumOSVersion</key>
-<string>1.0</string>
-<key>CFBundleSupportedPlatforms</key>
-<array>
-<string>XROS</string>
-</array>
-<key>NSPrincipalClass</key>
-<string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>nettle</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>nettle</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>87.88.520</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>XROS</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>87.88.520</string>
+	<key>MinimumOSVersion</key>
+	<string>1.0</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Sources/nettle.xcframework/xros-arm64/nettle.framework/Info.plist
+++ b/Sources/nettle.xcframework/xros-arm64/nettle.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>nettle</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.kintan.ksplayer.libshaderc-combined</string>
+	<string>com.iliasak91.ffmpegkit.nettle</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/copy_fixed_plists.sh
+++ b/copy_fixed_plists.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Script to copy fixed Info.plist files from DerivedData to FFmpegKit repository
+# This script finds all Info.plist files in DerivedData that have been fixed
+# and copies them to the corresponding locations in the FFmpegKit repo
+
+echo "🔍 Searching for fixed Info.plist files in DerivedData..."
+
+# Find DerivedData directory
+DERIVED_DATA_DIR="$HOME/Library/Developer/Xcode/DerivedData"
+
+# Find FFmpegKit in DerivedData
+FFMPEGKIT_CACHE_DIR=$(find "$DERIVED_DATA_DIR" -name "ffmpeg-kit*" -type d 2>/dev/null | head -1)
+
+if [ -z "$FFMPEGKIT_CACHE_DIR" ]; then
+    echo "❌ Could not find FFmpegKit in DerivedData"
+    echo "   Make sure you have built your project with FFmpegKit dependency"
+    exit 1
+fi
+
+echo "📁 Found FFmpegKit cache at: $FFMPEGKIT_CACHE_DIR"
+
+# Find all Info.plist files in the cache that have the new bundle ID pattern
+echo "🔍 Searching for fixed Info.plist files..."
+
+# Find all Info.plist files that contain the new bundle ID pattern
+FIXED_PLISTS=$(find "$FFMPEGKIT_CACHE_DIR" -name "Info.plist" -exec grep -l "com.iliasak91.ffmpegkit" {} \; 2>/dev/null)
+
+if [ -z "$FIXED_PLISTS" ]; then
+    echo "❌ No fixed Info.plist files found in cache"
+    echo "   Make sure you have manually fixed the bundle IDs in DerivedData first"
+    exit 1
+fi
+
+echo "✅ Found $(echo "$FIXED_PLISTS" | wc -l | tr -d ' ') fixed Info.plist files"
+
+# Counter for copied files
+copied_count=0
+
+# Process each fixed plist file
+echo "$FIXED_PLISTS" | while read -r cache_plist; do
+    # Extract the relative path from the cache
+    relative_path=$(echo "$cache_plist" | sed "s|$FFMPEGKIT_CACHE_DIR/||")
+    
+    # Find the corresponding path in the repository
+    # The structure should be similar: Sources/<framework>.xcframework/...
+    repo_plist="./Sources/$(echo "$relative_path" | sed -n 's|.*/\([^/]*\.xcframework\)/.*|\1|p')"
+    
+    if [ -n "$repo_plist" ] && [ -d "$repo_plist" ]; then
+        # Find the exact matching file in the repo
+        framework_name=$(echo "$relative_path" | sed -n 's|.*/\([^/]*\)\.xcframework/.*|\1|p')
+        
+        if [ -n "$framework_name" ]; then
+            # Construct the target path in the repo
+            target_path="./Sources/${framework_name}.xcframework/$(echo "$relative_path" | sed -n "s|.*${framework_name}\.xcframework/||p")"
+            
+            if [ -f "$target_path" ]; then
+                echo "📋 Copying: $cache_plist"
+                echo "   To: $target_path"
+                
+                # Copy the file
+                if cp "$cache_plist" "$target_path"; then
+                    echo "   ✅ Copied successfully"
+                    copied_count=$((copied_count + 1))
+                else
+                    echo "   ❌ Failed to copy"
+                fi
+            else
+                echo "⚠️  Target file not found: $target_path"
+            fi
+        fi
+    fi
+done
+
+echo ""
+echo "🎉 Copy operation completed!"
+echo "📊 Files copied: $copied_count"
+
+echo ""
+echo "🔍 Verifying changes in repository..."
+remaining_old_ids=$(grep -r "com.kintan.ksplayer.libshaderc-combined" ./Sources --include="*.plist" | wc -l)
+echo "⚠️  Found $remaining_old_ids remaining old bundle IDs"
+
+if [ "$remaining_old_ids" -gt 0 ]; then
+    echo "📋 Remaining files with old bundle IDs:"
+    grep -r "com.kintan.ksplayer.libshaderc-combined" ./Sources --include="*.plist"
+else
+    echo "✅ All bundle IDs have been fixed!"
+fi
+
+echo ""
+echo "🚀 Ready to commit and push changes!" 

--- a/fix_bundle_ids.sh
+++ b/fix_bundle_ids.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script to fix bundle IDs in FFmpegKit frameworks
+# This script will change all bundle IDs from "com.kintan.ksplayer.libshaderc-combined" 
+# to "com.iliasak91.ffmpegkit.[framework-name]"
+
+echo "Fixing bundle IDs in FFmpegKit frameworks..."
+
+# Find all Info.plist files in xcframework directories
+find ./Sources -name "Info.plist" -path "*/xcframework/*" | while read -r plist_file; do
+    # Extract framework name from path
+    framework_name=$(echo "$plist_file" | sed -n 's/.*\/\([^\/]*\)\.framework\/Info\.plist/\1/p')
+    
+    if [ -n "$framework_name" ]; then
+        # Create new bundle ID
+        new_bundle_id="com.iliasak91.ffmpegkit.$(echo "$framework_name" | tr '[:upper:]' '[:lower:]')"
+        
+        echo "Fixing $framework_name: $new_bundle_id"
+        
+        # Update the bundle ID
+        plutil -replace CFBundleIdentifier -string "$new_bundle_id" "$plist_file"
+    fi
+done
+
+echo "Bundle ID fix completed!" 

--- a/fix_bundle_ids.sh
+++ b/fix_bundle_ids.sh
@@ -1,25 +1,82 @@
 #!/bin/bash
 
-# Script to fix bundle IDs in FFmpegKit frameworks
-# This script will change all bundle IDs from "com.kintan.ksplayer.libshaderc-combined" 
-# to "com.iliasak91.ffmpegkit.[framework-name]"
+# FFmpegKit Bundle ID Fix Script
+# This script fixes the bundle identifier collision issue in FFmpegKit
 
-echo "Fixing bundle IDs in FFmpegKit frameworks..."
+echo "🔧 Starting FFmpegKit Bundle ID Fix..."
 
-# Find all Info.plist files in xcframework directories
-find ./Sources -name "Info.plist" -path "*/xcframework/*" | while read -r plist_file; do
-    # Extract framework name from path
-    framework_name=$(echo "$plist_file" | sed -n 's/.*\/\([^\/]*\)\.framework\/Info\.plist/\1/p')
+# Function to replace bundle ID in a file
+replace_bundle_id() {
+    local file="$1"
+    local old_id="$2"
+    local new_id="$3"
     
-    if [ -n "$framework_name" ]; then
-        # Create new bundle ID
-        new_bundle_id="com.iliasak91.ffmpegkit.$(echo "$framework_name" | tr '[:upper:]' '[:lower:]')"
-        
-        echo "Fixing $framework_name: $new_bundle_id"
-        
-        # Update the bundle ID
-        plutil -replace CFBundleIdentifier -string "$new_bundle_id" "$plist_file"
+    if grep -q "$old_id" "$file"; then
+        sed -i '' "s/$old_id/$new_id/g" "$file"
+        echo "✅ Fixed: $file"
     fi
+}
+
+# Define the mappings
+declare -A bundle_mappings=(
+    ["libshaderc_combined"]="com.iliasak91.ffmpegkit.libshaderc_combined"
+    ["libfontconfig"]="com.iliasak91.ffmpegkit.libfontconfig"
+    ["gmp"]="com.iliasak91.ffmpegkit.gmp"
+    ["gnutls"]="com.iliasak91.ffmpegkit.gnutls"
+    ["hogweed"]="com.iliasak91.ffmpegkit.hogweed"
+    ["lcms2"]="com.iliasak91.ffmpegkit.lcms2"
+    ["libass"]="com.iliasak91.ffmpegkit.libass"
+    ["Libavcodec"]="com.iliasak91.ffmpegkit.libavcodec"
+    ["Libavdevice"]="com.iliasak91.ffmpegkit.libavdevice"
+    ["Libavfilter"]="com.iliasak91.ffmpegkit.libavfilter"
+    ["Libavformat"]="com.iliasak91.ffmpegkit.libavformat"
+    ["Libavutil"]="com.iliasak91.ffmpegkit.libavutil"
+    ["Libswresample"]="com.iliasak91.ffmpegkit.libswresample"
+    ["Libswscale"]="com.iliasak91.ffmpegkit.libswscale"
+    ["nettle"]="com.iliasak91.ffmpegkit.nettle"
+    ["libfribidi"]="com.iliasak91.ffmpegkit.libfribidi"
+    ["libfreetype"]="com.iliasak91.ffmpegkit.libfreetype"
+    ["libsmbclient"]="com.iliasak91.ffmpegkit.libsmbclient"
+    ["libsrt"]="com.iliasak91.ffmpegkit.libsrt"
+    ["libbluray"]="com.iliasak91.ffmpegkit.libbluray"
+    ["libdav1d"]="com.iliasak91.ffmpegkit.libdav1d"
+    ["libplacebo"]="com.iliasak91.ffmpegkit.libplacebo"
+    ["libzvbi"]="com.iliasak91.ffmpegkit.libzvbi"
+    ["MoltenVK"]="com.iliasak91.ffmpegkit.moltenvk"
+    ["libharfbuzz"]="com.iliasak91.ffmpegkit.libharfbuzz"
+    ["libmpv"]="com.iliasak91.ffmpegkit.libmpv"
+)
+
+old_bundle_id="com.kintan.ksplayer.libshaderc-combined"
+
+# Process each framework
+for framework in "${!bundle_mappings[@]}"; do
+    new_bundle_id="${bundle_mappings[$framework]}"
+    
+    echo "🔧 Processing $framework.xcframework..."
+    
+    # Find all Info.plist files for this framework
+    find ./Sources -path "*$framework.xcframework*" -name "Info.plist" | while read -r file; do
+        replace_bundle_id "$file" "$old_bundle_id" "$new_bundle_id"
+    done
 done
 
-echo "Bundle ID fix completed!" 
+echo ""
+echo "🎉 Bundle ID fix completed!"
+echo "📊 Summary:"
+echo "   - Old bundle ID: $old_bundle_id"
+echo "   - Frameworks processed: ${#bundle_mappings[@]}"
+echo ""
+echo "🔍 Verifying changes..."
+
+# Verify no old bundle IDs remain
+remaining_old_ids=$(grep -r "$old_bundle_id" ./Sources/ 2>/dev/null | wc -l)
+if [ "$remaining_old_ids" -eq 0 ]; then
+    echo "✅ No old bundle IDs found - all fixed!"
+else
+    echo "⚠️  Found $remaining_old_ids remaining old bundle IDs"
+    grep -r "$old_bundle_id" ./Sources/ 2>/dev/null
+fi
+
+echo ""
+echo "🚀 Ready to commit and push changes!" 


### PR DESCRIPTION
   This PR changes the generated CFBundleIdentifier for all FFmpegKit frameworks to use a unique prefix (com.iliasak91.ffmpegkit.*) to avoid bundle identifier conflicts on install.